### PR TITLE
Release 1.2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ To include in your maven project use the following repository and dependency
     <repositories>
     ...
 		<repository>
-			<id>jottley</id>
-			<url>https://dl.bintray.com/jottley/jottley/</url>
+			<id>jcenter</id>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
     ...
 	</repositories>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spring Social Salesforce [![Build Status](https://travis-ci.org/jottley/spring-social-salesforce.svg?branch=master)](https://travis-ci.org/jottley/spring-social-salesforce)
+# Spring Social Salesforce [![Build Status](https://travis-ci.org/jottley/spring-social-salesforce.svg?branch=master)](https://travis-ci.org/jottley/spring-social-salesforce) [ ![Download](https://api.bintray.com/packages/jottley/jottley/spring-social-salesforce/images/download.svg?version=1.2.0.RELEASE) ](https://bintray.com/jottley/jottley/spring-social-salesforce/1.2.0.RELEASE/link)
 
 Spring Social Salesforce is a Spring Social extension that provides connection support and api binding for Salesforce
 REST API.
@@ -8,6 +8,31 @@ To check out the project and build from source, do the following:
     git clone git://github.com/jottley/spring-social-salesforce.git
     cd spring-social-salesforce
     mvn clean install
+    
+## Maven
+To include in your maven project use the following repository and dependency
+
+    <repositories>
+    ...
+		<repository>
+			<id>jottley</id>
+			<url>https://dl.bintray.com/jottley/jottley/</url>
+		</repository>
+    ...
+	</repositories>
+    
+    <dependencies>
+    ...
+        <dependency>
+			<groupId>org.springframework.social</groupId>
+			<artifactId>spring-social-salesforce</artifactId>
+			<version>${salesforce.version}</version>
+		</dependency>
+    ...
+    </dependencies>
+    
+## Quickstart
+There is a spring boot quickstart app available at https://github.com/jottley/spring-social-salesforce-quickstart
 
 ## Supported Operations
  - Retrieve all available api versions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spring Social Salesforce [![Build Status](https://travis-ci.org/jottley/spring-social-salesforce.svg?branch=master)](https://travis-ci.org/jottley/spring-social-salesforce) [ ![Download](https://api.bintray.com/packages/jottley/jottley/spring-social-salesforce/images/download.svg?version=1.2.0.RELEASE) ](https://bintray.com/jottley/jottley/spring-social-salesforce/1.2.0.RELEASE/link)
+# Spring Social Salesforce [![Build Status](https://travis-ci.org/jottley/spring-social-salesforce.svg?branch=master)](https://travis-ci.org/jottley/spring-social-salesforce) [ ![Download](https://api.bintray.com/packages/jottley/jottley/spring-social-salesforce/images/download.svg?version=1.2.0.1.RELEASE) ](https://bintray.com/jottley/jottley/spring-social-salesforce/1.2.0.1.RELEASE/link)
 
 Spring Social Salesforce is a Spring Social extension that provides connection support and api binding for Salesforce
 REST API.
@@ -26,7 +26,7 @@ To include in your maven project use the following repository and dependency
         <dependency>
 			<groupId>org.springframework.social</groupId>
 			<artifactId>spring-social-salesforce</artifactId>
-			<version>${salesforce.version}</version>
+			<version>1.2.0.1.RELEASE</version>
 		</dependency>
     ...
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.social</groupId>
 	<artifactId>spring-social-salesforce</artifactId>
-	<version>1.2.0.RELEASE</version>
+	<version>1.3.0.SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>spring-social-salesforce</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.social</groupId>
 	<artifactId>spring-social-salesforce</artifactId>
-	<version>1.3.0.SNAPSHOT</version>
+	<version>1.2.0.1.RELEASE</version>
 	<packaging>jar</packaging>
 
 	<name>spring-social-salesforce</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<spring-social.version>1.1.4.RELEASE</spring-social.version>
 		<httpclient.version>4.3.6</httpclient.version>
 		<servlet.version>3.0.1</servlet.version>
-		<jackson.version>2.6.1</jackson.version>
+		<jackson.version>2.8.10</jackson.version>
 		<joor.version>0.9.4</joor.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION
Upgrade Jackson Library to 2.8.10 to address CVE-2017-7525 and CVE-2017-15095.  While we are not directly affected by this issue we want to play nice for those who may pull in the jackson library through our dependency.