### PR TITLE
Issue #22: QueryTemplate nextPage calculation

### DIFF
--- a/src/main/java/org/springframework/social/salesforce/api/impl/QueryTemplate.java
+++ b/src/main/java/org/springframework/social/salesforce/api/impl/QueryTemplate.java
@@ -50,7 +50,7 @@ public class QueryTemplate extends AbstractSalesForceOperations<Salesforce> impl
     public QueryResult nextPage(String pathOrToken) {
         requireAuthorization();
         if (pathOrToken.contains("/")) {
-            return restTemplate.getForObject(api.getBaseUrl() + pathOrToken, QueryResult.class);
+            return restTemplate.getForObject(api.getInstanceUrl() + pathOrToken, QueryResult.class);
         } else {
             return restTemplate.getForObject(api.getBaseUrl() + "/" + getVersion() + "/query/{token}", QueryResult.class, pathOrToken);
         }

--- a/src/test/java/org/springframework/social/salesforce/api/impl/QueryTemplateTest.java
+++ b/src/test/java/org/springframework/social/salesforce/api/impl/QueryTemplateTest.java
@@ -140,4 +140,19 @@ public class QueryTemplateTest extends AbstractSalesforceTest {
         assertEquals("Frank", genePointContacts.getRecords().get(0).getAttributes().get("LastName"));
     }
 
+    @Test
+    public void validNextPageQuery() {
+        mockServer.expect(requestTo("https://na7.salesforce.com/services/data/" + salesforce.apiOperations().getVersion() + "/query?q=SELECT+Id%2C+Name%2C+BillingCity+FROM+Account"))
+                .andExpect(method(GET))
+                .andRespond(withStatus(HttpStatus.OK).body(loadResource("query-simple.json")).headers(responseHeaders));
+        mockServer.expect(requestTo("https://na7.salesforce.com/services/data/" + salesforce.apiOperations().getVersion() + "/query/01gD0000002HU6KIAW-2000"))
+                .andExpect(method(GET))
+                .andRespond(withStatus(HttpStatus.OK).body(loadResource("query-simple.json")).headers(responseHeaders));
+
+        QueryResult result = salesforce.queryOperations().query("SELECT Id, Name, BillingCity FROM Account");
+        String nextRecordsUrl = result.getNextRecordsUrl();
+        assertEquals("/services/data/v37.0/query/01gD0000002HU6KIAW-2000", nextRecordsUrl);
+        salesforce.queryOperations().nextPage(nextRecordsUrl);
+    }
+
 }


### PR DESCRIPTION
Replace usage of api.getBaseUrl() by api.getInstanceUrl() in nextPage method for QueryTemplate
because pathOrToken has the following format /services/data/v37.0/query/{Id}