### PR TITLE
added ability to retrieve deleted items

### DIFF
--- a/src/main/java/org/springframework/social/salesforce/api/QueryOperations.java
+++ b/src/main/java/org/springframework/social/salesforce/api/QueryOperations.java
@@ -30,6 +30,16 @@ public interface QueryOperations {
      */
     QueryResult query(String query);
 
+    /**
+     * Execute SOQL query and return the first page of results
+     *
+     * @param query The SOQL query to execute
+     * @param includeDeletedItems if result should include deleted items
+     * documentation https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_queryall.htm
+     * @return QueryResult
+     */
+    QueryResult query(String query, boolean includeDeletedItems);
+
     /*
      * Retrieve next page of results based on argument from url (usually from query result "nextRecordsUrl")
      */

--- a/src/main/java/org/springframework/social/salesforce/api/impl/QueryTemplate.java
+++ b/src/main/java/org/springframework/social/salesforce/api/impl/QueryTemplate.java
@@ -41,8 +41,14 @@ public class QueryTemplate extends AbstractSalesForceOperations<Salesforce> impl
 
     @Override
     public QueryResult query(String query) {
+        return query(query, false);
+    }
+
+    @Override
+    public QueryResult query(String query, boolean includeDeletedItems) {
+        String queryType = includeDeletedItems ? "/queryAll" : "/query";
         requireAuthorization();
-        URI uri = URIBuilder.fromUri(api.getBaseUrl() + "/" + getVersion() + "/query").queryParam("q", query).build();
+        URI uri = URIBuilder.fromUri(api.getBaseUrl() + "/" + getVersion() + queryType).queryParam("q", query).build();
         return restTemplate.getForObject(uri, QueryResult.class);
     }
 


### PR DESCRIPTION
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_queryall.htm

I use your library and before just **query** returned deleted items too, but with isDeleted=true
Now for the same functionality we should use **queryAll**
Please add this functionality to your library